### PR TITLE
Fix index out of range issue. Get sdr repository only once.

### DIFF
--- a/ipmi/sdr.go
+++ b/ipmi/sdr.go
@@ -59,6 +59,8 @@ var CmdReserveDeviceSdr = IpmiRequest{[]byte{0x4, 0x22}, 0x0, 0x0}
 
 var CmdGetSdrRepositoryAllocationInfo = IpmiRequest{[]byte{0xa, 0x21}, 0x0, 0x0}
 
+var sdrInfos []SdrInfo
+
 //AddData byte[6]: 
 //byte[0] =reservationId[0]
 //byte[1] = reservationId[1]
@@ -122,11 +124,13 @@ func (sp *SdrParser) GetComponentHealth(host string)(map[string]string,error){
 	if err != nil{
 		return nil,err
 	}
-	sdrInfos,err := sp.ScanSdr(deviceId.IsDeviceSdr,host)
-	if err != nil{
-		return nil,err
+    if sdrInfos == nil {
+        var err error
+        sdrInfos,err = sp.ScanSdr(deviceId.IsDeviceSdr,host)
+        if err != nil{
+	        return nil,err
+        }
 	}
-
 	sdrStatus,err := sp.GetSdrData(sdrInfos,host)
 	if err != nil{
 		return nil,err
@@ -476,7 +480,7 @@ func (sp *SdrParser) GetSdrData(sdrs []SdrInfo,host string) ([]SensorStatus, err
 	sensorStatus = make([]SensorStatus,len(sdrs))
 	var cmd = CmdGetSensorReading.Clone()
 	for i,sdr := range sdrs{
-		cmd.Data[3] = byte(sdr.SensorNumber)
+		cmd.Data[2] = byte(sdr.SensorNumber)
 		response, err := sp.IpmiLayer.ExecRaw(cmd, host)
 		if err != nil{
 			return nil,err


### PR DESCRIPTION
Fixes #7 

need to rebuild snapteld with the following change:
```
diff --git a/control/available_plugin.go b/control/available_plugin.go
index 310d8d05..3a9208a7 100644
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -43,7 +43,7 @@ import (
 
 const (
        // DefaultClientTimeout - default timeout for a client connection attempt
-       DefaultClientTimeout = time.Second * 10
+       DefaultClientTimeout = time.Second * 100
        // DefaultHealthCheckTimeout - default timeout for a health check
        DefaultHealthCheckTimeout = time.Second * 10
        // DefaultHealthCheckFailureLimit - how any consecutive health check timeouts must occur to trigger a failure
```